### PR TITLE
fix(fetch-terms): retry branch lookup on 401 and align GITHUB_API_TOKEN naming

### DIFF
--- a/src/pipeline/references/external-references-service.js
+++ b/src/pipeline/references/external-references-service.js
@@ -107,7 +107,7 @@ async function fetchExternalSpecs(spec) {
   } catch (e) {
     Logger.error("Unexpected error in fetchExternalSpecs", {
       context: 'Failed while fetching terms from external specifications',
-      hint: 'Check your internet connection and verify all external_specs URLs in specs.json are valid. Run with GITHUB_PAT set if accessing private repos',
+      hint: 'Check your internet connection and verify all external_specs URLs in specs.json are valid. Run with GITHUB_API_TOKEN set if accessing private repos',
       details: e.message
     });
     return [];

--- a/src/pipeline/references/fetch-terms-from-index.js
+++ b/src/pipeline/references/fetch-terms-from-index.js
@@ -76,13 +76,25 @@ async function fetchAllTermsFromIndex(token, owner, repo, options = {}) {
 
             try {
                 const mainBranchUrl = `https://api.github.com/repos/${owner}/${repo}/branches/main`;
-                const branchResponse = await axios.get(mainBranchUrl, { headers });
-                if (branchResponse.status === 200) {
+                let branchResponse;
+                try {
+                    branchResponse = await axios.get(mainBranchUrl, { headers });
+                } catch (authError) {
+                    if (authError.response && authError.response.status === 401) {
+                        // Token is present but invalid; retry without auth since the repo is public.
+                        Logger.warn(`GITHUB_API_TOKEN is invalid or expired — retrying branch lookup without authentication`);
+                        branchResponse = await axios.get(mainBranchUrl);
+                    } else {
+                        throw authError;
+                    }
+                }
+                if (branchResponse && branchResponse.status === 200) {
                     commitHash = branchResponse.data.commit.sha;
                     Logger.success(`Got commit hash from main branch: ${commitHash}`);
                 }
             } catch (error) {
-                Logger.error(`Could not get commit hash from main branch: ${error.message}`);
+                // Commit hash is optional — warn and continue rather than blocking the build.
+                Logger.warn(`Could not get commit hash from main branch: ${error.message}`);
             }
         } else {
             Logger.warn('No GitHub Pages URL provided, falling back to repository method');
@@ -194,6 +206,8 @@ async function fetchAllTermsFromIndex(token, owner, repo, options = {}) {
             } else if (error.response.status === 403 && error.response.headers['x-ratelimit-remaining'] === '0') {
                 const resetTime = new Date(Number(error.response.headers['x-ratelimit-reset']) * 1000);
                 Logger.error(`GitHub API rate limit exceeded. Try again after ${resetTime.toLocaleString()}`);
+            } else if (error.response.status === 401) {
+                Logger.error(`GitHub API authentication failed. Verify that GITHUB_API_TOKEN is valid and has read access to the repository.`);
             } else {
                 Logger.error(`Error fetching data: ${error.response.status} ${error.response.statusText}`);
             }

--- a/src/pipeline/references/fetch-terms-from-index.test.js
+++ b/src/pipeline/references/fetch-terms-from-index.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const axios = require('axios');
+const { fetchAllTermsFromIndex } = require('./fetch-terms-from-index');
+
+jest.mock('axios');
+jest.mock('../../utils/logger', () => ({
+    process: jest.fn(),
+    success: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+}));
+const Logger = require('../../utils/logger');
+
+const MINIMAL_INDEX_HTML = `
+<html><body>
+  <dl class="terms-and-definitions-list">
+    <dt class="term-local">
+      <span id="term:example-term"></span>
+      <span class="term-local-original-term">example-term</span>
+    </dt>
+    <dd><p>An example definition.</p></dd>
+  </dl>
+</body></html>`;
+
+const OWNER = 'test-owner';
+const REPO  = 'test-repo';
+const GH_PAGE_URL = 'https://test-owner.github.io/test-repo/';
+
+describe('fetchAllTermsFromIndex — authentication error handling', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('succeeds with valid token: fetches commit hash then index.html', async () => {
+        axios.get
+            .mockResolvedValueOnce({ status: 200, data: { commit: { sha: 'abc123' } } })
+            .mockResolvedValueOnce({ status: 200, data: MINIMAL_INDEX_HTML });
+
+        const result = await fetchAllTermsFromIndex('valid-token', OWNER, REPO, { ghPageUrl: GH_PAGE_URL });
+
+        expect(result).not.toBeNull();
+        expect(result.sha).toBe('abc123');
+        expect(result.terms.length).toBe(1);
+        expect(result.terms[0].term).toBe('example-term');
+    });
+
+    test('on 401 from branch fetch: warns, retries without auth, and returns commit hash', async () => {
+        const authError = Object.assign(new Error('Request failed with status 401'), {
+            response: { status: 401 }
+        });
+
+        axios.get
+            .mockRejectedValueOnce(authError)
+            .mockResolvedValueOnce({ status: 200, data: { commit: { sha: 'def456' } } })
+            .mockResolvedValueOnce({ status: 200, data: MINIMAL_INDEX_HTML });
+
+        const result = await fetchAllTermsFromIndex('bad-token', OWNER, REPO, { ghPageUrl: GH_PAGE_URL });
+
+        expect(Logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('GITHUB_API_TOKEN is invalid or expired')
+        );
+        expect(result).not.toBeNull();
+        expect(result.sha).toBe('def456');
+        expect(result.terms.length).toBe(1);
+    });
+
+    test('on 401 then retry also fails: warns and continues with null commit hash', async () => {
+        const authError = Object.assign(new Error('Request failed with status 401'), {
+            response: { status: 401 }
+        });
+        const networkError = new Error('Network unreachable');
+
+        axios.get
+            .mockRejectedValueOnce(authError)
+            .mockRejectedValueOnce(networkError)
+            .mockResolvedValueOnce({ status: 200, data: MINIMAL_INDEX_HTML });
+
+        const result = await fetchAllTermsFromIndex('bad-token', OWNER, REPO, { ghPageUrl: GH_PAGE_URL });
+
+        expect(Logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('Could not get commit hash from main branch')
+        );
+        expect(result).not.toBeNull();
+        expect(result.sha).toBeNull();
+        expect(result.terms.length).toBe(1);
+    });
+
+    test('non-401 branch error: warns without triggering 401 retry path', async () => {
+        const serverError = Object.assign(new Error('Request failed with status 500'), {
+            response: { status: 500 }
+        });
+
+        axios.get
+            .mockRejectedValueOnce(serverError)
+            .mockResolvedValueOnce({ status: 200, data: MINIMAL_INDEX_HTML });
+
+        const result = await fetchAllTermsFromIndex('valid-token', OWNER, REPO, { ghPageUrl: GH_PAGE_URL });
+
+        expect(Logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('Could not get commit hash from main branch')
+        );
+        expect(Logger.warn).not.toHaveBeenCalledWith(
+            expect.stringContaining('GITHUB_API_TOKEN is invalid or expired')
+        );
+        expect(result).not.toBeNull();
+    });
+});


### PR DESCRIPTION
Closes #290.

When `GITHUB_API_TOKEN` is set but invalid, the branch lookup returned a 401 and logged a misleading `Logger.error("Could not get commit hash from main branch")` — implying a hard failure even though commit hash is optional and term collection can still succeed.

**Changes:**
- `fetch-terms-from-index.js` — on 401 from the branch endpoint, warn and retry without auth (safe for public repos); downgrade the outer commit-hash failure from `Logger.error` to `Logger.warn`; add a dedicated 401 branch to the outer catch with a clear auth failure message
- `external-references-service.js` — fix `GITHUB_PAT` → `GITHUB_API_TOKEN` in the user-facing hint string to match the rest of the codebase
- `fetch-terms-from-index.test.js` *(new)* — 4 Jest tests covering: valid token, 401 retry success, 401 retry then retry fails (graceful continue), non-401 error (no spurious retry)

All 215 existing tests pass.
